### PR TITLE
Add simple form validation to custom meet tab

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
-import type { NextPage, GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import React, { ReactElement } from 'react';
 import styles from '../styles/Home.module.css';
 
 interface TabsProps {
@@ -52,36 +52,45 @@ function DemoMeetingTab({ label }: { label: string }) {
 }
 
 function CustomConnectionTab({ label }: { label: string }) {
-  const [liveKitUrl, setLiveKitUrl] = useState<string | undefined>();
-  const [token, setToken] = useState<string | undefined>();
-
   const router = useRouter();
-  const join = () => {
-    router.push(`/custom/?liveKitUrl=${liveKitUrl}&token=${token}`);
+  const onSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    const formDate = new FormData(event.target as HTMLFormElement);
+    const serverUrl = formDate.get('serverUrl');
+    const token = formDate.get('token');
+    router.push(`/custom/?liveKitUrl=${serverUrl}&token=${token}`);
   };
   return (
-    <div className={styles.tabContent}>
+    <form className={styles.tabContent} onSubmit={onSubmit}>
       <p style={{ marginTop: 0 }}>
         Connect LiveKit Meet with a custom server using LiveKit Cloud or LiveKit Server.
       </p>
-      {/* <label>LiveKit URL</label> */}
-      <input type="url" placeholder="URL" onChange={(ev) => setLiveKitUrl(ev.target.value)}></input>
-      {/* <label>Token</label> */}
-      <input type="text" placeholder="Token" onChange={(ev) => setToken(ev.target.value)}></input>
+      <input
+        id="serverUrl"
+        name="serverUrl"
+        type="url"
+        placeholder="LiveKit Server URL: wss://<>.livekit.cloud"
+        required
+      />
+      <textarea
+        id="token"
+        name="token"
+        placeholder="Token"
+        required
+        rows={9}
+        style={{ padding: '1px 2px', fontSize: 'inherit', lineHeight: 'inherit' }}
+      />
       <hr
         style={{ width: '100%', borderColor: 'rgba(255, 255, 255, 0.15)', marginBlock: '1rem' }}
       />
       <button
-        style={{
-          paddingInline: '1.25rem',
-          width: '100%',
-        }}
+        style={{ paddingInline: '1.25rem', width: '100%' }}
         className="lk-button"
-        onClick={join}
+        type="submit"
       >
         Connect
       </button>
-    </div>
+    </form>
   );
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -55,9 +55,9 @@ function CustomConnectionTab({ label }: { label: string }) {
   const router = useRouter();
   const onSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    const formDate = new FormData(event.target as HTMLFormElement);
-    const serverUrl = formDate.get('serverUrl');
-    const token = formDate.get('token');
+    const formData = new FormData(event.target as HTMLFormElement);
+    const serverUrl = formData.get('serverUrl');
+    const token = formData.get('token');
     router.push(`/custom/?liveKitUrl=${serverUrl}&token=${token}`);
   };
   return (
@@ -69,7 +69,7 @@ function CustomConnectionTab({ label }: { label: string }) {
         id="serverUrl"
         name="serverUrl"
         type="url"
-        placeholder="LiveKit Server URL: wss://<>.livekit.cloud"
+        placeholder="LiveKit Server URL: wss://*.livekit.cloud"
         required
       />
       <textarea


### PR DESCRIPTION
This PR adds basic form validation to the form in the custom tab.

- Converted to actual HTML form
- Both input fields are now required
- Added new placeholder text to give a better example of the required input
- URLs without a protocol will not be accepted and will be marked as error.
- Changed the token input field to a text area.
- Increased the size of the token field to indicate the size of a normal token and to make it possible to see the entire token at once.
<img width="531" alt="Screenshot 2023-05-02 at 16 31 27" src="https://user-images.githubusercontent.com/11357413/235700128-f618dec5-2748-4e8a-b19b-314f52dab614.png">
<img width="504" alt="Screenshot 2023-05-02 at 16 31 35" src="https://user-images.githubusercontent.com/11357413/235700192-5491d50f-fac4-4b83-b5e8-9548ff0e992e.png">

