### PR TITLE
add option to disable single peer connection mode

### DIFF
--- a/app/rooms/[roomName]/PageClientImpl.tsx
+++ b/app/rooms/[roomName]/PageClientImpl.tsx
@@ -39,6 +39,7 @@ export function PageClientImpl(props: {
   region?: string;
   hq: boolean;
   codec: VideoCodec;
+  singlePeerConnection: boolean;
 }) {
   const [preJoinChoices, setPreJoinChoices] = React.useState<LocalUserChoices | undefined>(
     undefined,
@@ -82,7 +83,11 @@ export function PageClientImpl(props: {
         <VideoConferenceComponent
           connectionDetails={connectionDetails}
           userChoices={preJoinChoices}
-          options={{ codec: props.codec, hq: props.hq }}
+          options={{
+            codec: props.codec,
+            hq: props.hq,
+            singlePeerConnection: props.singlePeerConnection,
+          }}
         />
       )}
     </main>
@@ -95,6 +100,7 @@ function VideoConferenceComponent(props: {
   options: {
     hq: boolean;
     codec: VideoCodec;
+    singlePeerConnection: boolean;
   };
 }) {
   const keyProvider = new ExternalE2EEKeyProvider();
@@ -129,7 +135,7 @@ function VideoConferenceComponent(props: {
       adaptiveStream: true,
       dynacast: true,
       e2ee: keyProvider && worker && e2eeEnabled ? { keyProvider, worker } : undefined,
-      singlePeerConnection: true,
+      singlePeerConnection: props.options.singlePeerConnection,
     };
   }, [props.userChoices, props.options.hq, props.options.codec]);
 

--- a/app/rooms/[roomName]/page.tsx
+++ b/app/rooms/[roomName]/page.tsx
@@ -12,6 +12,7 @@ export default async function Page({
     region?: string;
     hq?: string;
     codec?: string;
+    singlePC?: string;
   }>;
 }) {
   const _params = await params;
@@ -21,6 +22,7 @@ export default async function Page({
       ? _searchParams.codec
       : 'vp9';
   const hq = _searchParams.hq === 'true' ? true : false;
+  const singlePC = _searchParams.singlePC !== 'false';
 
   return (
     <PageClientImpl
@@ -28,6 +30,7 @@ export default async function Page({
       region={_searchParams.region}
       hq={hq}
       codec={codec}
+      singlePeerConnection={singlePC}
     />
   );
 }


### PR DESCRIPTION
defaults to singlePeerConnection being used. 

To disable append `?singlePC=false` to the URL