### PR TITLE
Enable WebAudio routing on iOS 26 for speaker selection

### DIFF
--- a/app/rooms/[roomName]/PageClientImpl.tsx
+++ b/app/rooms/[roomName]/PageClientImpl.tsx
@@ -25,6 +25,7 @@ import {
   RoomEvent,
   TrackPublishDefaults,
   VideoCaptureOptions,
+  isSafariSpeakerSelectionSupported,
 } from 'livekit-client';
 import { useRouter } from 'next/navigation';
 import { useSetupE2EE } from '@/lib/useSetupE2EE';
@@ -136,6 +137,9 @@ function VideoConferenceComponent(props: {
       dynacast: true,
       e2ee: keyProvider && worker && e2eeEnabled ? { keyProvider, worker } : undefined,
       singlePeerConnection: props.options.singlePeerConnection,
+      // webAudioMix routes remote audio through AudioContext, which respects AudioContext.setSinkId()
+      // on iOS 26 where HTMLMediaElement.setSinkId() silently has no effect for WebRTC audio.
+      webAudioMix: isSafariSpeakerSelectionSupported(),
     };
   }, [props.userChoices, props.options.hq, props.options.codec]);
 


### PR DESCRIPTION
requires https://github.com/livekit/client-sdk-js/pull/1635 and https://github.com/livekit/components-js/pull/1328

Routes remote audio through an AudioContext on iOS 26+ so that the Speaker Selection API can take effect. iOS renders WebRTC remote tracks via a pipeline that bypasses `HTMLMediaElement.setSinkId`; the AudioContext path lets the SDK redirect output via a shared relay element that iOS does honour. More details in the PR description of https://github.com/livekit/client-sdk-js/pull/1635