### PR TITLE
i18n: 汉化前端页面、README 和环境变量示例文件

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,29 @@
-# 1. Copy this file and rename it to .env.local
-# 2. Update the enviroment variables below.
+# 1. 复制此文件并重命名为 .env.local
+# 2. 更新下面的环境变量。
 
-# REQUIRED SETTINGS
+# 必需设置
 # ################# 
-# If you are using LiveKit Cloud, the API key and secret can be generated from the Cloud Dashboard.
+# 如果使用 LiveKit Cloud，API 密钥和密钥可从 Cloud 控制台生成。
 LIVEKIT_API_KEY=
 LIVEKIT_API_SECRET=
-# URL pointing to the LiveKit server. (example: `wss://my-livekit-project.livekit.cloud`)
+# 指向 LiveKit 服务器的 URL。(示例: `wss://my-livekit-project.livekit.cloud`)
 LIVEKIT_URL=
 
 
-# OPTIONAL SETTINGS
+# 可选设置
 # ################# 
-# Recording
+# 录制
 # S3_KEY_ID=
 # S3_KEY_SECRET=
 # S3_ENDPOINT=
 # S3_BUCKET=
 # S3_REGION=
 
-# PUBLIC
-# Uncomment settings menu when using a LiveKit Cloud, it'll enable Krisp noise filters.
+# 公共
+# 使用 LiveKit Cloud 时取消注释设置菜单，将启用 Krisp 降噪功能。
 # NEXT_PUBLIC_SHOW_SETTINGS_MENU=true
 # NEXT_PUBLIC_LK_RECORD_ENDPOINT=/api/record
 
-# Optional, to pipe logs to datadog
+# 可选，将日志发送到 Datadog
 # NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=client-token
 # NEXT_PUBLIC_DATADOG_SITE=datadog-site
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+## 项目概述
+
+LiveKit Meet — 基于 Next.js 15 (App Router) + @livekit/components-react 的开源视频会议应用。单包仓库，非 monorepo。
+
+## 开发命令
+
+- 包管理器: **pnpm** (packageManager 字段锁定版本，勿用 npm/yarn)
+- `pnpm dev` — 启动开发服务器 (localhost:3000)
+- `pnpm build` — 生产构建
+- `pnpm lint` — ESLint (next/core-web-vitals)
+- `pnpm lint:fix` — 自动修复 lint
+- `pnpm format:check` — Prettier 检查
+- `pnpm format:write` — Prettier 自动格式化
+- `pnpm test` — vitest run (无 watch 模式)
+
+CI 顺序: lint → format:check → test。提交前应按此顺序验证。
+
+## 测试
+
+- 框架: vitest，无独立配置文件，使用默认配置
+- 目前仅一个测试文件: `lib/getLiveKitURL.test.ts`
+- 运行单个测试: `pnpm test -- getLiveKitURL` (vitest 文件名过滤)
+
+## 代码风格
+
+- Prettier: singleQuote, trailingComma: all, semi: true, tabWidth: 2, printWidth: 100
+- 路径别名: `@/*` 映射到项目根目录 `./*`
+- TypeScript strict 模式
+
+## 架构要点
+
+### 路由结构
+
+- `/` — 首页，两个 tab: DemoMeeting / CustomConnection
+- `/rooms/[roomName]` — 主要会议页面 (动态路由)
+- `/custom` — 自定义服务器连接 (传入 liveKitUrl + token)
+- `/api/connection-details` — 服务端生成 participant token (GET)
+- `/api/record/start`, `/api/record/stop` — 录制控制 (GET)
+
+### 服务端 vs 客户端
+
+- `app/rooms/[roomName]/page.tsx` 是 Server Component，解析 searchParams 后传给 `PageClientImpl`
+- `PageClientImpl.tsx` 标记 `'use client'`，处理 Room 连接和 UI
+- API route `connection-details/route.ts` 使用 `livekit-server-sdk` 的 AccessToken 在服务端签发 JWT
+
+### E2EE (端到端加密)
+
+- passphrase 通过 URL hash fragment 传递 (非 searchParams)
+- `lib/useSetupE2EE.ts` 从 `location.hash` 读取 passphrase
+- 需要 Web Worker: `livekit-client/e2ee-worker`
+- next.config.js 设置 COOP/COEP header 以支持 SharedArrayBuffer (E2EE Worker 必需)
+- E2EE 启用时，av1/vp9 codec 会被降级为 undefined
+
+### 环境变量
+
+必需 (`.env.local`):
+- `LIVEKIT_API_KEY` — LiveKit API 密钥
+- `LIVEKIT_API_SECRET` — LiveKit API 密钥
+- `LIVEKIT_URL` — LiveKit 服务器 URL (wss://...)
+
+可选:
+- `NEXT_PUBLIC_SHOW_SETTINGS_MENU=true` — 启用设置菜单 (含 Krisp 降噪)
+- `NEXT_PUBLIC_LK_RECORD_ENDPOINT=/api/record` — 启用录制功能
+- `NEXT_PUBLIC_CONN_DETAILS_ENDPOINT` — 自定义连接详情端点 (默认 `/api/connection-details`)
+- `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN` / `NEXT_PUBLIC_DATADOG_SITE` — Datadog 日志
+- `S3_KEY_ID`, `S3_KEY_SECRET`, `S3_ENDPOINT`, `S3_BUCKET`, `S3_REGION` — 录制存储
+
+### 录制安全警告
+
+`app/api/record/start/route.ts` 和 `stop/route.ts` **无身份验证**，任何知道 roomName 的人都可启停录制。代码中有明确注释 "DO NOT USE THIS FOR PRODUCTION PURPOSES AS IS"。
+
+### LiveKit Cloud 区域路由
+
+`lib/getLiveKitURL.ts` 处理区域 URL 重写: `myproject.livekit.cloud` → `myproject.{region}.production.livekit.cloud`。staging 环境不插入 `production` 段。
+
+## LiveKit 文档
+
+LiveKit 是快速迭代的项目，始终参考最新文档。LiveKit 提供 MCP server: `https://docs.livekit.io/mcp`
+
+关键工具:
+- `get_docs_overview`, `get_pages` — 浏览文档结构
+- `docs_search` — 搜索文档 (优于 code_search)
+- `get_changelog` — 查看变更日志
+- `get_pricing_info` — 定价信息
+
+优先使用浏览类工具获取上下文，搜索类工具作为补充。
+
+## 部署
+
+- sandbox-production 分支通过 `sync-to-production.yaml` workflow 手动同步
+- 使用 `livekit-examples/sandbox-deploy-action@v1`

--- a/README.md
+++ b/README.md
@@ -5,38 +5,38 @@
 # LiveKit Meet
 
 <p>
-  <a href="https://meet.livekit.io"><strong>Try the demo</strong></a>
+  <a href="https://meet.livekit.io"><strong>在线演示</strong></a>
   •
   <a href="https://github.com/livekit/components-js">LiveKit Components</a>
   •
-  <a href="https://docs.livekit.io/">LiveKit Docs</a>
+  <a href="https://docs.livekit.io/">LiveKit 文档</a>
   •
   <a href="https://livekit.io/cloud">LiveKit Cloud</a>
   •
-  <a href="https://blog.livekit.io/">Blog</a>
+  <a href="https://blog.livekit.io/">博客</a>
 </p>
 
 <br>
 
-LiveKit Meet is an open source video conferencing app built on [LiveKit Components](https://github.com/livekit/components-js), [LiveKit Cloud](https://cloud.livekit.io/), and Next.js. It's been completely redesigned from the ground up using our new components library.
+LiveKit Meet 是一个基于 [LiveKit Components](https://github.com/livekit/components-js)、[LiveKit Cloud](https://cloud.livekit.io/) 和 Next.js 构建的开源视频会议应用。它使用全新的组件库从头重新设计。
 
-![LiveKit Meet screenshot](./.github/assets/livekit-meet.jpg)
+![LiveKit Meet 截图](./.github/assets/livekit-meet.jpg)
 
-## Tech Stack
+## 技术栈
 
-- This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
-- App is built with [@livekit/components-react](https://github.com/livekit/components-js/) library.
+- 基于 [Next.js](https://nextjs.org/) 项目，使用 [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) 初始化。
+- 应用使用 [@livekit/components-react](https://github.com/livekit/components-js/) 库构建。
 
-## Demo
+## 演示
 
-Give it a try at https://meet.livekit.io.
+访问 https://meet.livekit.io 在线体验。
 
-## Dev Setup
+## 开发环境搭建
 
-Steps to get a local dev setup up and running:
+本地开发环境搭建步骤：
 
-1. Run `pnpm install` to install all dependencies.
-2. Copy `.env.example` in the project root and rename it to `.env.local`.
-3. Update the missing environment variables in the newly created `.env.local` file.
-4. Run `pnpm dev` to start the development server and visit [http://localhost:3000](http://localhost:3000) to see the result.
-5. Start development 🎉
+1. 运行 `pnpm install` 安装所有依赖。
+2. 将项目根目录下的 `.env.example` 复制并重命名为 `.env.local`。
+3. 更新新创建的 `.env.local` 文件中缺失的环境变量。
+4. 运行 `pnpm dev` 启动开发服务器，访问 [http://localhost:3000](http://localhost:3000) 查看结果。
+5. 开始开发 🎉

--- a/app/custom/page.tsx
+++ b/app/custom/page.tsx
@@ -12,13 +12,13 @@ export default async function CustomRoomConnection(props: {
 }) {
   const { liveKitUrl, token, codec, singlePC } = await props.searchParams;
   if (typeof liveKitUrl !== 'string') {
-    return <h2>Missing LiveKit URL</h2>;
+    return <h2>缺少 LiveKit 服务器地址</h2>;
   }
   if (typeof token !== 'string') {
-    return <h2>Missing LiveKit token</h2>;
+    return <h2>缺少 LiveKit 访问令牌</h2>;
   }
   if (codec !== undefined && !isVideoCodec(codec)) {
-    return <h2>Invalid codec, if defined it has to be [{videoCodecs.join(', ')}].</h2>;
+    return <h2>无效的编解码器，可选值为 [{videoCodecs.join(', ')}]。</h2>;
   }
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,11 +6,11 @@ import { Toaster } from 'react-hot-toast';
 
 export const metadata: Metadata = {
   title: {
-    default: 'LiveKit Meet | Conference app build with LiveKit open source',
+    default: 'LiveKit Meet | 基于 LiveKit 开源项目构建的视频会议应用',
     template: '%s',
   },
   description:
-    'LiveKit is an open source WebRTC project that gives you everything needed to build scalable and real-time audio and/or video experiences in your applications.',
+    'LiveKit 是一个开源 WebRTC 项目，为您提供构建可扩展、实时音视频体验所需的一切。',
   twitter: {
     creator: '@livekitted',
     site: '@livekitted',
@@ -50,7 +50,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="zh-CN">
       <body data-lk-theme="default">
         <Toaster />
         {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,9 +54,9 @@ function DemoMeetingTab(props: { label: string }) {
   };
   return (
     <div className={styles.tabContent}>
-      <p style={{ margin: 0 }}>Try LiveKit Meet for free with our live demo project.</p>
+      <p style={{ margin: 0 }}>免费体验 LiveKit Meet 在线演示。</p>
       <button style={{ marginTop: '1rem' }} className="lk-button" onClick={startMeeting}>
-        Start Meeting
+        开始会议
       </button>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
@@ -66,11 +66,11 @@ function DemoMeetingTab(props: { label: string }) {
             checked={e2ee}
             onChange={(ev) => setE2ee(ev.target.checked)}
           ></input>
-          <label htmlFor="use-e2ee">Enable end-to-end encryption</label>
+          <label htmlFor="use-e2ee">启用端到端加密</label>
         </div>
         {e2ee && (
           <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
-            <label htmlFor="passphrase">Passphrase</label>
+            <label htmlFor="passphrase">加密密语</label>
             <input
               id="passphrase"
               type="password"
@@ -106,7 +106,7 @@ function CustomConnectionTab(props: { label: string }) {
   return (
     <form className={styles.tabContent} onSubmit={onSubmit}>
       <p style={{ marginTop: 0 }}>
-        Connect LiveKit Meet with a custom server using LiveKit Cloud or LiveKit Server.
+        使用 LiveKit Cloud 或 LiveKit Server 自定义服务器连接。
       </p>
       <input
         id="serverUrl"
@@ -118,7 +118,7 @@ function CustomConnectionTab(props: { label: string }) {
       <textarea
         id="token"
         name="token"
-        placeholder="Token"
+        placeholder="访问令牌"
         required
         rows={5}
         style={{ padding: '1px 2px', fontSize: 'inherit', lineHeight: 'inherit' }}
@@ -131,11 +131,11 @@ function CustomConnectionTab(props: { label: string }) {
             checked={e2ee}
             onChange={(ev) => setE2ee(ev.target.checked)}
           ></input>
-          <label htmlFor="use-e2ee">Enable end-to-end encryption</label>
+          <label htmlFor="use-e2ee">启用端到端加密</label>
         </div>
         {e2ee && (
           <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
-            <label htmlFor="passphrase">Passphrase</label>
+            <label htmlFor="passphrase">加密密语</label>
             <input
               id="passphrase"
               type="password"
@@ -154,7 +154,7 @@ function CustomConnectionTab(props: { label: string }) {
         className="lk-button"
         type="submit"
       >
-        Connect
+        连接
       </button>
     </form>
   );
@@ -167,34 +167,34 @@ export default function Page() {
         <div className="header">
           <img src="/images/livekit-meet-home.svg" alt="LiveKit Meet" width="360" height="45" />
           <h2>
-            Open source video conferencing app built on{' '}
+            基于{' '}
             <a href="https://github.com/livekit/components-js?ref=meet" rel="noopener">
               LiveKit&nbsp;Components
             </a>
-            ,{' '}
+            、{' '}
             <a href="https://livekit.io/cloud?ref=meet" rel="noopener">
               LiveKit&nbsp;Cloud
             </a>{' '}
-            and Next.js.
+            和 Next.js 构建的开源视频会议应用。
           </h2>
         </div>
-        <Suspense fallback="Loading">
+        <Suspense fallback="加载中">
           <Tabs>
-            <DemoMeetingTab label="Demo" />
-            <CustomConnectionTab label="Custom" />
+            <DemoMeetingTab label="演示" />
+            <CustomConnectionTab label="自定义" />
           </Tabs>
         </Suspense>
       </main>
       <footer data-lk-theme="default">
-        Hosted on{' '}
+        托管于{' '}
         <a href="https://livekit.io/cloud?ref=meet" rel="noopener">
           LiveKit Cloud
         </a>
-        . Source code on{' '}
+        。源代码托管于{' '}
         <a href="https://github.com/livekit/meet?ref=meet" rel="noopener">
           GitHub
         </a>
-        .
+        。
       </footer>
     </>
   );

--- a/app/rooms/[roomName]/PageClientImpl.tsx
+++ b/app/rooms/[roomName]/PageClientImpl.tsx
@@ -149,7 +149,7 @@ function VideoConferenceComponent(props: {
           room.setE2EEEnabled(true).catch((e) => {
             if (e instanceof DeviceUnsupportedError) {
               alert(
-                `You're trying to join an encrypted meeting, but your browser does not support it. Please update it to the latest version and try again.`,
+                `您正在尝试加入加密会议，但您的浏览器不支持此功能。请更新浏览器至最新版本后重试。`,
               );
               console.error(e);
             } else {
@@ -208,12 +208,12 @@ function VideoConferenceComponent(props: {
   const handleOnLeave = React.useCallback(() => router.push('/'), [router]);
   const handleError = React.useCallback((error: Error) => {
     console.error(error);
-    alert(`Encountered an unexpected error, check the console logs for details: ${error.message}`);
+    alert(`遇到意外错误，请查看控制台日志了解详情：${error.message}`);
   }, []);
   const handleEncryptionError = React.useCallback((error: Error) => {
     console.error(error);
     alert(
-      `Encountered an unexpected encryption error, check the console logs for details: ${error.message}`,
+      `遇到意外加密错误，请查看控制台日志了解详情：${error.message}`,
     );
   }, []);
 

--- a/lib/CameraSettings.tsx
+++ b/lib/CameraSettings.tsx
@@ -13,8 +13,8 @@ import Nature from '../public/background-images/ali-kazal-tbw_KQE3Cbg-unsplash.j
 
 // Background image paths
 const BACKGROUND_IMAGES = [
-  { name: 'Desk', path: Desk },
-  { name: 'Nature', path: Nature },
+  { name: '书桌', path: Desk },
+  { name: '自然', path: Nature },
 ];
 
 // Background options
@@ -76,14 +76,14 @@ export function CameraSettings() {
       )}
 
       <section className="lk-button-group">
-        <TrackToggle source={Track.Source.Camera}>Camera</TrackToggle>
+        <TrackToggle source={Track.Source.Camera}>摄像头</TrackToggle>
         <div className="lk-button-group-menu">
           <MediaDeviceMenu kind="videoinput" />
         </div>
       </section>
 
       <div style={{ marginTop: '10px' }}>
-        <div style={{ marginBottom: '8px' }}>Background Effects</div>
+        <div style={{ marginBottom: '8px' }}>背景效果</div>
         <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
           <button
             onClick={() => selectBackground('none')}
@@ -94,7 +94,7 @@ export function CameraSettings() {
               minWidth: '80px',
             }}
           >
-            None
+            无
           </button>
 
           <button
@@ -132,7 +132,7 @@ export function CameraSettings() {
                 fontSize: '12px',
               }}
             >
-              Blur
+              模糊
             </span>
           </button>
 

--- a/lib/Debug.tsx
+++ b/lib/Debug.tsx
@@ -116,16 +116,16 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
       <div className={styles.overlay}>
         <section id="room-info">
           <h3>
-            Room Info {room.name}: {roomSid}
+            房间信息 {room.name}: {roomSid}
           </h3>
         </section>
         <details open>
           <summary>
-            <b>Local Participant: {lp.identity}</b>
+            <b>本地参与者: {lp.identity}</b>
           </summary>
           <details open className={styles.detailsSection}>
             <summary>
-              <b>Published tracks</b>
+              <b>已发布轨道</b>
             </summary>
             <div>
               {Array.from(lp.trackPublications.values()).map((t) => (
@@ -138,8 +138,8 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
                   </div>
                   <table>
                     <tbody>
-                      <tr>
-                        <td>Kind</td>
+                       <tr>
+                        <td>类型</td>
                         <td>
                           {t.kind}&nbsp;
                           {t.kind === 'video' && (
@@ -150,7 +150,7 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
                         </td>
                       </tr>
                       <tr>
-                        <td>Bitrate</td>
+                        <td>比特率</td>
                         <td>{Math.ceil(t.track!.currentBitrate / 1000)} kbps</td>
                       </tr>
                     </tbody>
@@ -161,7 +161,7 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
           </details>
           <details open className={styles.detailsSection}>
             <summary>
-              <b>Permissions</b>
+              <b>权限</b>
             </summary>
             <div>
               <table>
@@ -187,7 +187,7 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
 
         <details>
           <summary>
-            <b>Remote Participants</b>
+            <b>远程参与者</b>
           </summary>
           {Array.from(room.remoteParticipants.values()).map((p) => (
             <details key={p.sid} className={styles.detailsSection}>
@@ -209,7 +209,7 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
                     <table>
                       <tbody>
                         <tr>
-                          <td>Kind</td>
+                          <td>类型</td>
                           <td>
                             {t.kind}&nbsp;
                             {t.kind === 'video' && (
@@ -220,12 +220,12 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
                           </td>
                         </tr>
                         <tr>
-                          <td>Status</td>
+                          <td>状态</td>
                           <td>{trackStatus(t)}</td>
                         </tr>
                         {t.track && (
                           <tr>
-                            <td>Bitrate</td>
+                            <td>比特率</td>
                             <td>{Math.ceil(t.track.currentBitrate / 1000)} kbps</td>
                           </tr>
                         )}
@@ -244,8 +244,8 @@ export const DebugMode = ({ logLevel }: { logLevel?: LogLevel }) => {
 
 function trackStatus(t: RemoteTrackPublication): string {
   if (t.isSubscribed) {
-    return t.isEnabled ? 'enabled' : 'disabled';
+    return t.isEnabled ? '已启用' : '已禁用';
   } else {
-    return 'unsubscribed';
+    return '未订阅';
   }
 }

--- a/lib/MicrophoneSettings.tsx
+++ b/lib/MicrophoneSettings.tsx
@@ -36,7 +36,7 @@ export function MicrophoneSettings() {
       }}
     >
       <section className="lk-button-group">
-        <TrackToggle source={Track.Source.Microphone}>Microphone</TrackToggle>
+        <TrackToggle source={Track.Source.Microphone}>麦克风</TrackToggle>
         <div className="lk-button-group-menu">
           <MediaDeviceMenu kind="audioinput" />
         </div>
@@ -48,7 +48,7 @@ export function MicrophoneSettings() {
         disabled={isNoiseFilterPending}
         aria-pressed={isNoiseFilterEnabled}
       >
-        {isNoiseFilterEnabled ? 'Disable' : 'Enable'} Enhanced Noise Cancellation
+        {isNoiseFilterEnabled ? '关闭' : '开启'}增强降噪
       </button>
     </div>
   );

--- a/lib/RecordingIndicator.tsx
+++ b/lib/RecordingIndicator.tsx
@@ -10,7 +10,7 @@ export function RecordingIndicator() {
     if (isRecording !== wasRecording) {
       setWasRecording(isRecording);
       if (isRecording) {
-        toast('This meeting is being recorded', {
+        toast('本次会议正在录制中', {
           duration: 3000,
           icon: '🎥',
           position: 'top-center',

--- a/lib/SettingsMenu.tsx
+++ b/lib/SettingsMenu.tsx
@@ -26,8 +26,8 @@ export function SettingsMenu(props: SettingsMenuProps) {
 
   const settings = React.useMemo(() => {
     return {
-      media: { camera: true, microphone: true, label: 'Media Devices', speaker: true },
-      recording: recordingEndpoint ? { label: 'Recording' } : undefined,
+      media: { camera: true, microphone: true, label: '媒体设备', speaker: true },
+      recording: recordingEndpoint ? { label: '录制' } : undefined,
     };
   }, []);
 
@@ -98,7 +98,7 @@ export function SettingsMenu(props: SettingsMenuProps) {
           <>
             {settings.media && settings.media.camera && (
               <>
-                <h3>Camera</h3>
+                <h3>摄像头</h3>
                 <section>
                   <CameraSettings />
                 </section>
@@ -106,7 +106,7 @@ export function SettingsMenu(props: SettingsMenuProps) {
             )}
             {settings.media && settings.media.microphone && (
               <>
-                <h3>Microphone</h3>
+                <h3>麦克风</h3>
                 <section>
                   <MicrophoneSettings />
                 </section>
@@ -114,9 +114,9 @@ export function SettingsMenu(props: SettingsMenuProps) {
             )}
             {settings.media && settings.media.speaker && (
               <>
-                <h3>Speaker & Headphones</h3>
+                <h3>扬声器与耳机</h3>
                 <section className="lk-button-group">
-                  <span className="lk-button">Audio Output</span>
+                  <span className="lk-button">音频输出</span>
                   <div className="lk-button-group-menu">
                     <MediaDeviceMenu kind="audiooutput"></MediaDeviceMenu>
                   </div>
@@ -127,15 +127,15 @@ export function SettingsMenu(props: SettingsMenuProps) {
         )}
         {activeTab === 'recording' && (
           <>
-            <h3>Record Meeting</h3>
+            <h3>录制会议</h3>
             <section>
               <p>
                 {isRecording
-                  ? 'Meeting is currently being recorded'
-                  : 'No active recordings for this meeting'}
+                  ? '会议正在录制中'
+                  : '当前没有正在进行的录制'}
               </p>
               <button disabled={processingRecRequest} onClick={() => toggleRoomRecording()}>
-                {isRecording ? 'Stop' : 'Start'} Recording
+                {isRecording ? '停止' : '开始'}录制
               </button>
             </section>
           </>
@@ -146,7 +146,7 @@ export function SettingsMenu(props: SettingsMenuProps) {
           className={`lk-button`}
           onClick={() => layoutContext?.widget.dispatch?.({ msg: 'toggle_settings' })}
         >
-          Close
+          关闭
         </button>
       </div>
     </div>


### PR DESCRIPTION
- 页面标题、按钮、表单、提示信息等用户可见文本全部汉化
- README.md 全文翻译为中文
- .env.example 注释汉化
- 新增 AGENTS.md 仓库指引文件（中文）